### PR TITLE
Make a scope-limited query when "limit search to scope" is on

### DIFF
--- a/core/api.js
+++ b/core/api.js
@@ -54,7 +54,7 @@ function call(i, ret, uname) {
   }
 }
 
-if(!store.db)   store.db   = {entries: {}, count: 0};
+if(!store.db)   store.db   = {entries: [], count: 0};
 if(!store.pass) store.pass = { hashes: {}, tokens: {}};
 
 let actions = {};

--- a/modules/disk.js
+++ b/modules/disk.js
@@ -121,7 +121,7 @@ function state_change() {
       intervals[k] = commons.setInterval(acts[k], this[k]);
   }
   if(first_go) {
-    store.db   = read('data/dict.db',     {entries: {},  count: 0 }),
+    store.db   = read('data/dict.db',     {entries: [],  count: 0 }),
     store.pass = read('data/accounts.db', { hashes: {}, tokens: {}}); 
     first_go = false;
   } else if(!this) {

--- a/static/frontend.js
+++ b/static/frontend.js
@@ -196,8 +196,10 @@ app = new Vue({
         this.scroll_up = true;
         return;
       }
+      let parsed_query = this.parse_query();
+      if (this.limit_search) parsed_query = ['and', parsed_query, ['scope', this.scope_name]];
       this.current_search_request = apisend(
-        {action: 'search', query: this.parse_query()},
+        {action: 'search', query: parsed_query},
         function(data) {
           app.scroll_up = true;
           app.result_cache = data.results.map(app.process_entry);

--- a/static/frontend.js
+++ b/static/frontend.js
@@ -197,7 +197,7 @@ app = new Vue({
         return;
       }
       let parsed_query = this.parse_query();
-      if (this.limit_search) parsed_query = ['and', parsed_query, ['scope', this.scope_name]];
+      if (this.limit_search) parsed_query = ['and', ['scope', this.scope_name], parsed_query];
       this.current_search_request = apisend(
         {action: 'search', query: parsed_query},
         function(data) {


### PR DESCRIPTION
Previously, "limit search to en:  **yes**" did nothing as far as I can tell.

Also, default store.db.entries to `[]` (I was getting `store.db.entries.push is not a function` testing locally).