### PR TITLE
Fix normalization of input that already contains ı

### DIFF
--- a/static/frontend.js
+++ b/static/frontend.js
@@ -19,9 +19,11 @@ function normalize_head(head) {
   return head
     .trim()
     .replace(/\s+/g, " ")
+    .replace(/ı/g, "i")
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[\u2018\u2019x-]/gi, "'")
+    .replace(/^'+/, "")
     .replace(/(\s*)[^aeiouy]+[aeiouy]/gi, (m, s) => m + (s ? "\u0309" : "\u0304"))
     .replace("\u0304", "")
     .normalize("NFC")


### PR DESCRIPTION
Also, strip `'` from the front when normalizing. I noticed fagri defined `'aı'āı` but that should really be normalized to `aı'āı` (for the same reason that `ea` is not `'ea`). 