### PR TITLE
Allow `head:CVq*` style glob searches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "toadua",
       "version": "0.42.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
In a `key:value` search term, interpret the following "glob" syntax in `value`:

* `*` matches 0 or more characters.
* `?` matches 1 character.
* `C` matches a Toaq consonant.
* `V` matches a Toaq vowel.
* `V+` matches 1 or more Toaq vowels.

Examples: `head:CVqCV` finds words of that shape. `head:*oq` finds words ending in `oq`. `head:????` finds four-letter words. `user:l*` finds words by authors with names starting with L.