### PR TITLE
Set result card lang to its scope

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -60,7 +60,7 @@
 		</div>
 	</nav>
 	<div id="results">
-		<div class="card" v-for="result in results">
+		<div class="card" v-for="result in results" :lang="result.scope">
 			<div class="title">
 				<h2>
 					<a


### PR DESCRIPTION
This should give proper CJK variant rendering to the `ja` and `zh` scopes. (It also helps screen readers I think.) Not tested 🤐 