### PR TITLE
Fix the arity filter

### DIFF
--- a/core/search.ts
+++ b/core/search.ts
@@ -136,12 +136,9 @@ let operations: Record<string, Operation> = (search.operations = {
 			([n]) =>
 			entry =>
 				entry.$.body
-					.split(/[;.]/)
-					.map(_ => {
-						let matches = _.match(/▯/g);
-						return matches ? matches.length : -1;
-					})
-					.reduce(Math.max, -1) === n,
+					.split(/[;.!?；。]/)
+					.map(sentence => sentence.match(/▯/g)?.length ?? 0)
+					.reduce((a, b) => Math.max(a, b)) === n,
 	},
 	term: {
 		type: OperationType.Textual,


### PR DESCRIPTION
This filter was mainly broken because all the arguments of the reduce callback (including the current index and the array itself) were being passed to `Math.max`. A couple of smaller issues were that it assigned nullary entries the arity -1, and didn't work with some less common punctuation.